### PR TITLE
Upgrade to Handle 9.1.0 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>handle</artifactId>
-            <version>6.2.5.02</version>
+            <version>9.1.0.v20190416</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
+++ b/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
@@ -31,7 +31,7 @@ import net.handle.hdllib.HandleStorage;
 import net.handle.hdllib.HandleValue;
 import net.handle.hdllib.ScanCallback;
 import net.handle.hdllib.Util;
-import net.handle.util.StreamTable;
+import net.cnri.util.StreamTable;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -50,7 +50,7 @@ import com.google.gson.JsonSyntaxException;
  * <p>
  * This class is intended to be embedded in the CNRI Handle Server. It conforms
  * to the HandleStorage interface that was delivered with Handle Server version
- * 6.2.0.
+ * 9.1.0.
  * </p>
  *
  * @author Andrea Bollini


### PR DESCRIPTION
The current plugin will not work with the new version of Handle server coming in DSpace 7. This fixes the issues so that this plugin can continue to function.