### PR TITLE
Upgrade to Handle 9.3.0 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>net.handle</groupId>
             <artifactId>handle</artifactId>
-            <version>9.3.0-SNAPSHOT</version>
+            <version>9.3.0</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.dspace</groupId>
+            <groupId>net.handle</groupId>
             <artifactId>handle</artifactId>
-            <version>9.1.0.v20190416</version>
+            <version>9.3.0-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.5</version>
+            <version>2.8.6</version>
         </dependency>
     </dependencies>
 
@@ -228,5 +228,12 @@
        <system>Travis CI</system>
        <url>https://travis-ci.org/DSpace/Remote-Handle-Resolver</url>
    </ciManagement>
+
+    <repositories>
+        <repository>
+            <id>handle.net</id>
+            <url>https://handle.net/maven</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>handle</artifactId>
-            <version>6.2.5.02</version>
+            <version>9.1.0.v20190416</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
+++ b/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
@@ -50,7 +50,7 @@ import com.google.gson.JsonSyntaxException;
  * <p>
  * This class is intended to be embedded in the CNRI Handle Server. It conforms
  * to the HandleStorage interface that was delivered with Handle Server version
- * 9.1.0.
+ * 9.3.0.
  * </p>
  *
  * @author Andrea Bollini

--- a/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
+++ b/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
@@ -31,7 +31,7 @@ import net.handle.hdllib.HandleStorage;
 import net.handle.hdllib.HandleValue;
 import net.handle.hdllib.ScanCallback;
 import net.handle.hdllib.Util;
-import net.handle.util.StreamTable;
+import net.cnri.util.StreamTable;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -50,7 +50,7 @@ import com.google.gson.JsonSyntaxException;
  * <p>
  * This class is intended to be embedded in the CNRI Handle Server. It conforms
  * to the HandleStorage interface that was delivered with Handle Server version
- * 6.2.0.
+ * 9.1.0.
  * </p>
  *
  * @author Andrea Bollini


### PR DESCRIPTION
Add support for newer Handle server version. It's just a namespace change.

Also, this adds the CNRI maven repository for getting the handle artifact.