### PR TITLE
Require JDK >- 17, bump dependency versions to match DSpace main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,19 +55,19 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.23.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.10.1</version>
         </dependency>
     </dependencies>
 
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.11</version>
+                <version>3.0</version>
                 <configuration>
                     <header>LICENSE_HEADER</header>
                     <useDefaultExcludes>true</useDefaultExcludes>

--- a/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
+++ b/src/main/java/org/dspace/handle/MultiRemoteDSpaceRepositoryHandlePlugin.java
@@ -33,8 +33,8 @@ import net.handle.hdllib.ScanCallback;
 import net.handle.hdllib.Util;
 import net.cnri.util.StreamTable;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
@@ -70,7 +70,7 @@ public class MultiRemoteDSpaceRepositoryHandlePlugin implements HandleStorage
     private static final String PROPERTY_KEY = "dspace.handle.endpoint";
 
     /** log4j category */
-    private static final Logger log = Logger
+    private static final Logger log = org.apache.logging.log4j.LogManager
             .getLogger(MultiRemoteDSpaceRepositoryHandlePlugin.class);
 
     // maps prefixes to URLs from DSpace instances


### PR DESCRIPTION
This could be an alternative to the problem posed by #5 if there are not constraints on running older versions of Java... I basically tried to align the pom with DSpace main (as at pre-9.0) and enforce JDK17.
I've tried a build but not running it in practice...

This could even be a separate branch rather than a merge to main... or current main could get branched to 1.x or something.